### PR TITLE
 Fix grammar detection when multiple Moose packages are used 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 *.vsix
 out/
-syntaxes/
+syntaxes/**
 .vscode-test/
 npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@ All notable changes to the "perl-moose" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+- Fixed grammar detection when multiple Moose packages are used in the same file.
+
 
 ## [0.1.1] - 2019-03-23
 
-- Support for Mouse. @d9705996
+- Added support for Mouse. @d9705996
 
 
 ## [0.1.0] - 2019-03-13

--- a/package.json
+++ b/package.json
@@ -31,6 +31,27 @@
         ],
         "scopeName": "source.perl.moose",
         "path": "./syntaxes/perl-moose.tmLanguage.json"
+      },
+      {
+        "injectTo": [
+          "source.perl"
+        ],
+        "scopeName": "source.perl.package.moose",
+        "path": "./syntaxes/packages/moose.tmLanguage.json"
+      },
+      {
+        "injectTo": [
+          "source.perl"
+        ],
+        "scopeName": "source.perl.package.moose.role",
+        "path": "./syntaxes/packages/moose-role.tmLanguage.json"
+      },
+      {
+        "injectTo": [
+          "source.perl"
+        ],
+        "scopeName": "source.perl.package.moose.util.typeconstraints",
+        "path": "./syntaxes/packages/moose-util-typeconstraints.tmLanguage.json"
       }
     ]
   },

--- a/scripts/generate-syntax.js
+++ b/scripts/generate-syntax.js
@@ -4,26 +4,37 @@ var yaml = require('js-yaml');
 var fs   = require('fs');
 var path = require('path');
 
-var srcDir = process.env.SYNTAX_SRC_DIR || path.join(process.cwd(), 'src', 'syntaxes')
-var outDir = process.env.SYNTAX_OUT_DIR || path.join(process.cwd(), 'syntaxes')
+function processDir(srcDir, outDir) {
 
-if (!fs.existsSync(outDir)){
-    fs.mkdirSync(outDir);
+    if (!fs.existsSync(outDir)){
+        fs.mkdirSync(outDir);
+    }
+    
+    fs.readdirSync(srcDir).forEach(yamlFile => {
+        let ext = path.extname(yamlFile)
+        let fullPath = path.join(srcDir, yamlFile)
+        if (fs.statSync(fullPath).isDirectory()) {
+            processDir(
+                path.join(srcDir, yamlFile),
+                path.join(outDir, yamlFile)
+            );
+        } else if (ext.match(/^\.ya?ml$/)) {
+            let jsonFile = path.basename(yamlFile, ext) + '.json';
+            let jsonPath = path.join(outDir, jsonFile);
+            let yamlPath = path.join(srcDir, yamlFile);
+            try {
+                let src = yaml.safeLoad(fs.readFileSync(yamlPath, 'utf8'));
+                fs.writeFileSync(jsonPath, JSON.stringify(src, null, '  '));
+                console.log(jsonPath);
+             } catch (e) {
+                console.error(e);
+                process.exit(1);
+            }
+        }
+    });
 }
 
-fs.readdirSync(srcDir).forEach(yamlFile => {
-    let ext = path.extname(yamlFile)
-    if (ext.match(/^\.ya?ml$/)) {
-        let jsonFile = path.basename(yamlFile, ext) + '.json';
-        let jsonPath = path.join(outDir, jsonFile);
-        let yamlPath = path.join(srcDir, yamlFile);
-        try {
-            let src = yaml.safeLoad(fs.readFileSync(yamlPath, 'utf8'));
-            fs.writeFileSync(jsonPath, JSON.stringify(src, null, '  '));
-            console.log(jsonPath);
-         } catch (e) {
-            console.error(e);
-            process.exit(1);
-        }
-    }
-});
+
+var src = process.env.SYNTAX_SRC_DIR || path.join(process.cwd(), 'src', 'syntaxes')
+var out = process.env.SYNTAX_OUT_DIR || path.join(process.cwd(), 'syntaxes')
+processDir(src, out);

--- a/src/syntaxes/packages/moose-role.tmLanguage.yaml
+++ b/src/syntaxes/packages/moose-role.tmLanguage.yaml
@@ -1,0 +1,24 @@
+$schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json'
+information_for_contributors:
+  - >-
+    To modify Perl Moose Textmate grammar you mus edit the file
+    src/syntaxes/perl-moose.tmLanguage.yaml then, run following
+    command to generate extension source code.
+  - npm run generate:syntax
+
+name: Moose::Role
+scopeName: source.perl.package.moose.role
+injectionSelector: L:meta.role.moose.perl -comment -string -text
+patterns:
+  - include: '#moose_role'
+
+repository:
+  moose_role:
+    name: meta.role.moose.perl
+    patterns:
+      - name: constant.language.type.modifier.moose.perl
+        match: \b(-traits)\s*(?==>)
+      - name: keyword.other.role.moose.perl
+        match: \b(requires|excludes)\b
+      - include: 'source.perl.package.moose'
+

--- a/src/syntaxes/packages/moose-util-typeconstraints.tmLanguage.yaml
+++ b/src/syntaxes/packages/moose-util-typeconstraints.tmLanguage.yaml
@@ -1,0 +1,44 @@
+$schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json'
+information_for_contributors:
+  - >-
+    To modify Perl Moose Textmate grammar you mus edit the file
+    src/syntaxes/perl-moose.tmLanguage.yaml then, run following
+    command to generate extension source code.
+  - npm run generate:syntax
+
+name: Moose::Util::TypeConstraints
+scopeName: source.perl.package.moose.util.typeconstraints
+injectionSelector: L:meta.type.constraint.moose.perl -comment -string -text
+patterns:
+  - include: '#moose_type_constraint'
+
+repository:
+  moose_type_constraint:
+    patterns:
+      - name: keyword.control.moose.perl
+        match: \b(type|subtype|as|where|message|inline_as|match_on_type)\b
+      - name: keyword.control.moose.perl
+        match: (?<!->)\b(coerce)\b
+      - name: keyword.control.moose.perl
+        match: \b(from|via)\b
+      - name:  keyword.other.type.moose.perl
+        match: \b(class_type|role_type|maybe_type|duck_type|enum|union)\b
+      - name:  support.function.moose.perl
+        match: \b(find|register|create_(parameterized|class|role|enum|duck)|find_or_(parse|create_isa|create_does))_type_constraint\b
+      - name:  support.function.moose.perl
+        match: \b(normalize_type_constraint_name)\b
+      - name:  support.function.moose.perl
+        match: \b(create_type_constraint_union)\b
+      - name:  support.function.moose.perl
+        match: \b(create_named_type_constraint_union)\b
+      - name:  support.function.moose.perl
+        match: \b(get_type_constraint_registry)\b
+      - name:  support.function.moose.perl
+        match: \b(list_all_(builtin_type_constraints|type_constraints))\b
+      - name:  support.function.moose.perl
+        match: \b(export_type_constraints_as_functions)\b
+      - name:  support.function.moose.perl
+        match: \b(get_all_parameterizable_types)\b
+      - name:  support.function.moose.perl
+        match: \b(add_parameterizable_type)\b
+

--- a/src/syntaxes/packages/moose.tmLanguage.yaml
+++ b/src/syntaxes/packages/moose.tmLanguage.yaml
@@ -1,0 +1,50 @@
+$schema: 'https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json'
+information_for_contributors:
+  - >-
+    To modify Perl Moose Textmate grammar you mus edit the file
+    src/syntaxes/perl-moose.tmLanguage.yaml then, run following
+    command to generate extension source code.
+  - npm run generate:syntax
+
+name: Moose
+scopeName: source.perl.package.moose
+injectionSelector: L:meta.moose.perl -comment -string -text
+patterns:
+  - include: '#moose'
+
+repository:
+  moose:
+    patterns:
+      - begin: (?<=use)\s+(Goose|Gouse|Goo)(?=[\s;])
+        name:  entity.name.type.class.perl
+      - match: \s*(-meta_name)\b
+        captures:
+          '1':
+            name: entity.other.attribute-name.moose.perl
+        name: constant.language.type.modifier.moose.perl
+      # Todo: review if we need to remove entity.name.class.moose.perl
+      - match: \b(extends|with)(?:\s+([-a-zA-Z0-9_]+))?\s*
+        captures:
+          '1':
+            name: keyword.control.import.moose.perl
+          '2':
+            name: entity.name.class.moose.perl
+        name: keyword.control.moose.perl
+      - match: \b(has)(?:\s+(\+|)([-a-zA-Z0-9_]+))?\s*
+        captures:
+          '1':
+            name:  keyword.other.attribute.moose.perl
+          '2':
+            name: storage.modifier.attribute.moose.perl
+          '3':
+            name: entity.other.attribute-name.moose.perl
+      - match: \b(auto_deref|builder|clearer|coerce|default|documentation|does|handles|is|isa|lazy|lazy_build|metaclass|predicate|required|role_attribute|traits|trigger|weak_ref)\s*(?==>)
+        name: constant.language.has.key.moose.perl
+      - match: \b(before|after|around|override|augment)(?:\s+([-a-zA-Z0-9_]+))?
+        captures:
+          '1':
+            name: keyword.other.attribute.moose.perl
+          '2':
+            name: entity.name.function.perl
+      - match: \b(blessed|confess|inner|meta|super)\b
+        name:  support.function.moose.perl

--- a/src/syntaxes/perl-moose.tmLanguage.yaml
+++ b/src/syntaxes/perl-moose.tmLanguage.yaml
@@ -6,9 +6,8 @@ information_for_contributors:
     command to generate extension source code.
   - npm run generate:syntax
 
-#fileTypes: []
+scopeName: source.perl.moose
 injectionSelector: L:source.perl -comment -string -text
-#name: Perl Moose
 patterns:
   - include: '#moose_packages'
 
@@ -26,7 +25,6 @@ repository:
             name: entity.name.class.moose.perl
         end: (\b)(?=^\s*package\s|no\s+\1[\s;])
         patterns:
-          - include: '#moose'
           - include: '#source'
       - name: meta.role.moose.perl
         begin: (?<=use)\s+((?:Moose|Mouse|Moo)::Role)(?=[\s;])
@@ -35,7 +33,6 @@ repository:
             name: entity.name.class.moose.perl
         end: (\b)(?=^\s*package\s|no\s+\1[\s;])
         patterns:
-          - include: '#moose_role'
           - include: '#source'
       - name: meta.type.constraint.moose.perl
         begin: (?<=use)\s+((?:Moose|Mouse)::Util::TypeConstraints)(?=[\s;])
@@ -44,82 +41,4 @@ repository:
             name: entity.name.class.moose.perl
         end: (\b)(?=^\s*package\s|no\s+\1[\s;])
         patterns:
-          - include: '#moose_type_constraint'
           - include: '#source'
-
-  # This section contains Moose related syntax
-  moose:
-    patterns:
-      - match: \s*(-meta_name)\b
-        captures:
-          '1':
-            name: entity.other.attribute-name.moose.perl
-        name: constant.language.type.modifier.moose.perl
-      # Todo: review if we need to remove entity.name.class.moose.perl
-      - match: \b(extends|with)(?:\s+([-a-zA-Z0-9_]+))?\s*
-        captures:
-          '1':
-            name: keyword.control.import.moose.perl
-          '2':
-            name: entity.name.class.moose.perl
-        name: keyword.control.moose.perl
-      - match: \b(has)(?:\s+(\+|)([-a-zA-Z0-9_]+))?\s*
-        captures:
-          '1':
-            name:  keyword.other.attribute.moose.perl
-          '2':
-            name: storage.modifier.attribute.moose.perl
-          '3':
-            name: entity.other.attribute-name.moose.perl
-      - match: \b(auto_deref|builder|clearer|coerce|default|documentation|does|handles|is|isa|lazy|lazy_build|metaclass|predicate|required|role_attribute|traits|trigger|weak_ref)\s*(?==>)
-        name: constant.language.has.key.moose.perl
-      - match: \b(before|after|around|override|augment)(?:\s+([-a-zA-Z0-9_]+))?
-        captures:
-          '1':
-            name: keyword.other.attribute.moose.perl
-          '2':
-            name: entity.name.function.perl
-      - match: \b(blessed|confess|inner|meta|super)\b
-        name:  support.function.moose.perl
-
-  # This section contains Moose::Role related syntax
-  moose_role:
-    name: meta.role.moose.perl
-    patterns:
-      - name: constant.language.type.modifier.moose.perl
-        match: \b(-traits)\s*(?==>)
-      - name: keyword.other.role.moose.perl
-        match: \b(requires|excludes)\b
-      - include: '#moose'
-
-  # This section contains Moose::Util::TypeConstraints related syntax
-  moose_type_constraint:
-    patterns:
-      - name: keyword.control.moose.perl
-        match: \b(type|subtype|as|where|message|inline_as|match_on_type)\b
-      - name: keyword.control.moose.perl
-        match: (?<!->)\b(coerce)\b
-      - name: keyword.control.moose.perl
-        match: \b(from|via)\b
-      - name:  keyword.other.type.moose.perl
-        match: \b(class_type|role_type|maybe_type|duck_type|enum|union)\b
-      - name:  support.function.moose.perl
-        match: \b(find|register|create_(parameterized|class|role|enum|duck)|find_or_(parse|create_isa|create_does))_type_constraint\b
-      - name:  support.function.moose.perl
-        match: \b(normalize_type_constraint_name)\b
-      - name:  support.function.moose.perl
-        match: \b(create_type_constraint_union)\b
-      - name:  support.function.moose.perl
-        match: \b(create_named_type_constraint_union)\b
-      - name:  support.function.moose.perl
-        match: \b(get_type_constraint_registry)\b
-      - name:  support.function.moose.perl
-        match: \b(list_all_(builtin_type_constraints|type_constraints))\b
-      - name:  support.function.moose.perl
-        match: \b(export_type_constraints_as_functions)\b
-      - name:  support.function.moose.perl
-        match: \b(get_all_parameterizable_types)\b
-      - name:  support.function.moose.perl
-        match: \b(add_parameterizable_type)\b
-
-scopeName: source.perl.moose

--- a/testFixture/colorize-fixtures/TestLanguageInjection.pm
+++ b/testFixture/colorize-fixtures/TestLanguageInjection.pm
@@ -9,7 +9,7 @@ This file is used to to test VSCode Colorization
 #########################################################
 
 # Pattern:    use Moose
-package TestMooseInject {   
+package TestMooseInjectSource {   
     use Moose;
 
     # Assert: comment.line.number-sign.perl
@@ -27,3 +27,38 @@ package TestMooseInject {
     }
 }
 
+########################################################################
+# Test:       Multiple package grammars can be loaded at the same time #
+########################################################################
+
+# Pattern:    use Moose
+package TestMooseInjectPackages {
+    # Assert: meta.moose.perl
+    use Moose;
+
+    # Assert: meta.type.constraint.moose.perl
+    use Moose::Util::TypeConstraints;
+
+    # Assert: keyword.other.attribute.moose.perl
+    has 'attr' => ( is => 'ro', required => 0 );
+
+    # Assert: keyword.control.moose.perl
+    subtype 'TestSubType', as 'Str';
+}
+
+# Pattern: moose
+package TestMooseRoleMoose {
+    use Moose::Role;
+
+    # Assert: keyword.other.attribute.moose.perl string.quoted.single.perl
+    has 'attribute' => (
+        is       => 'ro',
+        required =>0
+    );
+
+    # Assert: keyword.other.role.moose.perl
+    requires 'required_attr';
+
+    # Assert: keyword.other.attribute.moose.perl string.quoted.single.perl
+    augment 'base_method1' => sub { };
+}

--- a/testFixture/colorize-fixtures/TestMoose.pm
+++ b/testFixture/colorize-fixtures/TestMoose.pm
@@ -29,13 +29,25 @@ package TestMooseRole {
 ###############################################
 
 # Pattern:    use Moose
-package TestMoosePackages {
+package TestMoosePackage {
     # Assert: entity.name.class.moose.perl
     use Moose;
 }
 
+# Pattern:    use Moo
+package TestMooPackage {
+    # Assert: entity.name.class.moose.perl
+    use Moo;
+}
+
+# Pattern:    use Mouse
+package TestMousePackage {
+    # Assert: entity.name.class.moose.perl
+    use Mouse;
+}
+
 # Pattern:    use Moose
-package TestMoosePackagesNo {
+package TestMoosePackageNo {
     # Assert: entity.name.class.moose.perl
     use Moose;
 

--- a/testFixture/colorize-fixtures/TestMooseRole.pm
+++ b/testFixture/colorize-fixtures/TestMooseRole.pm
@@ -20,6 +20,18 @@ package TestMooseRole {
     use Moose::Role;
 }
 
+# Pattern:    use Moo
+package TestMooRole {
+    # Assert: entity.name.class.moose.perl
+    use Moo::Role;
+}
+
+# Pattern:    use Mouse
+package TestMouseRole {
+    # Assert: entity.name.class.moose.perl
+    use Mouse::Role;
+}
+
 # Pattern:    use Moose
 package TestMooseRoleNo {
     # Assert: entity.name.class.moose.perl

--- a/testFixture/colorize-fixtures/TestMooseTypeConstraints.pm
+++ b/testFixture/colorize-fixtures/TestMooseTypeConstraints.pm
@@ -3,11 +3,22 @@ Perl Moose packages to test VSCode colorize
 This file is used to to test VSCode Colorization
 =cut
 
+#########
+# Stubs #
+#########
+
+sub subtype {};
+
 
 ##########################################################
 # Test:       Moose TypeConstraints syntax is colorized  #
 # Repository: moose_type_constraint                      #
 ##########################################################
+
+# Pattern:    use Moose::Util::TypeConstraints
+use Mouse::Util::TypeConstraints;
+
+no Mouse::Util::TypeConstraints;
 
 # Pattern:    use Moose::Util::TypeConstraints
 use Moose::Util::TypeConstraints;
@@ -60,5 +71,4 @@ Moose::Util::TypeConstraints::add_parameterizable_type($types[0]);
 no Moose::Util::TypeConstraints;
 
 # Assert: !meta.type.constraint.moose.perl
-sub subtype {};
 subtype();

--- a/testFixture/colorize-results/TestLanguageInjection_pm.json
+++ b/testFixture/colorize-results/TestLanguageInjection_pm.json
@@ -154,7 +154,7 @@
 		}
 	},
 	{
-		"c": "TestMooseInject",
+		"c": "TestMooseInjectSource",
 		"t": "source.perl meta.class.perl entity.name.type.class.perl",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -849,6 +849,1458 @@
 	{
 		"c": "}",
 		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#######################################################################",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Test:       Multiple package grammars can be loaded at the same time #",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#######################################################################",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Pattern:    use Moose",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "package",
+		"t": "source.perl meta.class.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.class.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "TestMooseInjectPackages",
+		"t": "source.perl meta.class.perl entity.name.type.class.perl",
+		"r": {
+			"dark_plus": "entity.name.type: #4EC9B0",
+			"light_plus": "entity.name.type: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.type: #4EC9B0"
+		}
+	},
+	{
+		"c": " {",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: meta.moose.perl",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Moose",
+		"t": "source.perl meta.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.moose.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: meta.type.constraint.moose.perl",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl meta.moose.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Moose::Util::TypeConstraints",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "has",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
+		"r": {
+			"dark_plus": "keyword: #569CD6",
+			"light_plus": "keyword: #0000FF",
+			"dark_vs": "keyword: #569CD6",
+			"light_vs": "keyword: #0000FF",
+			"hc_black": "keyword: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl meta.leading-tabs",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "attr",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " ( ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "is ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl constant.language.has.key.moose.perl",
+		"r": {
+			"dark_plus": "constant.language: #569CD6",
+			"light_plus": "constant.language: #0000FF",
+			"dark_vs": "constant.language: #569CD6",
+			"light_vs": "constant.language: #0000FF",
+			"hc_black": "constant.language: #569CD6"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "ro",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ", ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "required ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl constant.language.has.key.moose.perl",
+		"r": {
+			"dark_plus": "constant.language: #569CD6",
+			"light_plus": "constant.language: #0000FF",
+			"dark_vs": "constant.language: #569CD6",
+			"light_vs": "constant.language: #0000FF",
+			"hc_black": "constant.language: #569CD6"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " 0 );",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: keyword.control.moose.perl",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "subtype",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl meta.leading-tabs keyword.control.moose.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl meta.leading-tabs",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "TestSubType",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ", ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "as",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl keyword.control.moose.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "Str",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Pattern: moose",
+		"t": "source.perl meta.moose.perl meta.type.constraint.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "package",
+		"t": "source.perl meta.class.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.class.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "TestMooseRoleMoose",
+		"t": "source.perl meta.class.perl entity.name.type.class.perl",
+		"r": {
+			"dark_plus": "entity.name.type: #4EC9B0",
+			"light_plus": "entity.name.type: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.type: #4EC9B0"
+		}
+	},
+	{
+		"c": " {",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Moose::Role",
+		"t": "source.perl meta.role.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: keyword.other.attribute.moose.perl string.quoted.single.perl",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "has",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
+		"r": {
+			"dark_plus": "keyword: #569CD6",
+			"light_plus": "keyword: #0000FF",
+			"dark_vs": "keyword: #569CD6",
+			"light_vs": "keyword: #0000FF",
+			"hc_black": "keyword: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "attribute",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.role.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " (",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.even-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "is       ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
+		"r": {
+			"dark_plus": "constant.language: #569CD6",
+			"light_plus": "constant.language: #0000FF",
+			"dark_vs": "constant.language: #569CD6",
+			"light_vs": "constant.language: #0000FF",
+			"hc_black": "constant.language: #569CD6"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.role.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "ro",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ",",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.even-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "required ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
+		"r": {
+			"dark_plus": "constant.language: #569CD6",
+			"light_plus": "constant.language: #0000FF",
+			"dark_vs": "constant.language: #569CD6",
+			"light_vs": "constant.language: #0000FF",
+			"hc_black": "constant.language: #569CD6"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.role.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": "0",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ");",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: keyword.other.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "requires",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.role.moose.perl",
+		"r": {
+			"dark_plus": "keyword: #569CD6",
+			"light_plus": "keyword: #0000FF",
+			"dark_vs": "keyword: #569CD6",
+			"light_vs": "keyword: #0000FF",
+			"hc_black": "keyword: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "required_attr",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: keyword.other.attribute.moose.perl string.quoted.single.perl",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "augment",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
+		"r": {
+			"dark_plus": "keyword: #569CD6",
+			"light_plus": "keyword: #0000FF",
+			"dark_vs": "keyword: #569CD6",
+			"light_vs": "keyword: #0000FF",
+			"hc_black": "keyword: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.begin.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "base_method1",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": "'",
+		"t": "source.perl meta.role.moose.perl string.quoted.single.perl punctuation.definition.string.end.perl",
+		"r": {
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "=>",
+		"t": "source.perl meta.role.moose.perl keyword.operator.comparison.perl",
+		"r": {
+			"dark_plus": "keyword.operator: #D4D4D4",
+			"light_plus": "keyword.operator: #000000",
+			"dark_vs": "keyword.operator: #D4D4D4",
+			"light_vs": "keyword.operator: #000000",
+			"hc_black": "keyword.operator: #D4D4D4"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "sub",
+		"t": "source.perl meta.role.moose.perl meta.function.perl storage.type.sub.perl",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl meta.function.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{ };",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl meta.role.moose.perl",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/testFixture/colorize-results/TestMooseRole_pm.json
+++ b/testFixture/colorize-results/TestMooseRole_pm.json
@@ -451,6 +451,336 @@
 		}
 	},
 	{
+		"c": " Pattern:    use Moo",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "package",
+		"t": "source.perl meta.class.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.class.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "TestMooRole",
+		"t": "source.perl meta.class.perl entity.name.type.class.perl",
+		"r": {
+			"dark_plus": "entity.name.type: #4EC9B0",
+			"light_plus": "entity.name.type: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.type: #4EC9B0"
+		}
+	},
+	{
+		"c": " {",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: entity.name.class.moose.perl",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Moo::Role",
+		"t": "source.perl meta.role.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Pattern:    use Mouse",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "package",
+		"t": "source.perl meta.class.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.class.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "TestMouseRole",
+		"t": "source.perl meta.class.perl entity.name.type.class.perl",
+		"r": {
+			"dark_plus": "entity.name.type: #4EC9B0",
+			"light_plus": "entity.name.type: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.type: #4EC9B0"
+		}
+	},
+	{
+		"c": " {",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: entity.name.class.moose.perl",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Mouse::Role",
+		"t": "source.perl meta.role.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl meta.role.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
 		"c": " Pattern:    use Moose",
 		"t": "source.perl meta.role.moose.perl comment.line.number-sign.perl",
 		"r": {
@@ -1167,7 +1497,7 @@
 	},
 	{
 		"c": "requires",
-		"t": "source.perl meta.role.moose.perl keyword.other.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.role.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -1178,7 +1508,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1277,7 +1607,7 @@
 	},
 	{
 		"c": "excludes",
-		"t": "source.perl meta.role.moose.perl keyword.other.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.role.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -1288,7 +1618,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1519,7 +1849,7 @@
 	},
 	{
 		"c": "has",
-		"t": "source.perl meta.role.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -1530,7 +1860,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1629,7 +1959,7 @@
 	},
 	{
 		"c": "is       ",
-		"t": "source.perl meta.role.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -1728,7 +2058,7 @@
 	},
 	{
 		"c": "required ",
-		"t": "source.perl meta.role.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",

--- a/testFixture/colorize-results/TestMooseTypeConstraints_pm.json
+++ b/testFixture/colorize-results/TestMooseTypeConstraints_pm.json
@@ -55,6 +55,149 @@
 		}
 	},
 	{
+		"c": "########",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Stubs #",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "########",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "sub",
+		"t": "source.perl meta.function.perl storage.type.sub.perl",
+		"r": {
+			"dark_plus": "storage.type: #569CD6",
+			"light_plus": "storage.type: #0000FF",
+			"dark_vs": "storage.type: #569CD6",
+			"light_vs": "storage.type: #0000FF",
+			"hc_black": "storage.type: #569CD6"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.function.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "subtype",
+		"t": "source.perl meta.function.perl entity.name.function.perl",
+		"r": {
+			"dark_plus": "entity.name.function: #DCDCAA",
+			"light_plus": "entity.name.function: #795E26",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.function: #DCDCAA"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.function.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "{",
+		"t": "source.perl punctuation.section.scope.begin.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl punctuation.section.scope.end.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
 		"c": "#########################################################",
 		"t": "source.perl comment.line.number-sign.perl",
 		"r": {
@@ -129,6 +272,94 @@
 			"dark_vs": "comment: #6A9955",
 			"light_vs": "comment: #008000",
 			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Pattern:    use Moose::Util::TypeConstraints",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Mouse::Util::TypeConstraints",
+		"t": "source.perl meta.type.constraint.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.type.constraint.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "no",
+		"t": "source.perl support.function.perl",
+		"r": {
+			"dark_plus": "support.function: #DCDCAA",
+			"light_plus": "support.function: #795E26",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "support.function: #DCDCAA"
+		}
+	},
+	{
+		"c": " Mouse::Util::TypeConstraints;",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{
@@ -3077,83 +3308,6 @@
 			"dark_vs": "comment: #6A9955",
 			"light_vs": "comment: #008000",
 			"hc_black": "comment: #7CA668"
-		}
-	},
-	{
-		"c": "sub",
-		"t": "source.perl meta.function.perl storage.type.sub.perl",
-		"r": {
-			"dark_plus": "storage.type: #569CD6",
-			"light_plus": "storage.type: #0000FF",
-			"dark_vs": "storage.type: #569CD6",
-			"light_vs": "storage.type: #0000FF",
-			"hc_black": "storage.type: #569CD6"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.perl meta.function.perl",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
-		"c": "subtype",
-		"t": "source.perl meta.function.perl entity.name.function.perl",
-		"r": {
-			"dark_plus": "entity.name.function: #DCDCAA",
-			"light_plus": "entity.name.function: #795E26",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "entity.name.function: #DCDCAA"
-		}
-	},
-	{
-		"c": " ",
-		"t": "source.perl meta.function.perl",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
-		"c": "{",
-		"t": "source.perl punctuation.section.scope.begin.perl",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
-		"c": "}",
-		"t": "source.perl punctuation.section.scope.end.perl",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
-		}
-	},
-	{
-		"c": ";",
-		"t": "source.perl",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF"
 		}
 	},
 	{

--- a/testFixture/colorize-results/TestMoose_pm.json
+++ b/testFixture/colorize-results/TestMoose_pm.json
@@ -298,7 +298,7 @@
 	},
 	{
 		"c": "has",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -309,7 +309,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -320,7 +320,7 @@
 	},
 	{
 		"c": "attribute",
-		"t": "source.perl meta.moose.perl entity.other.attribute-name.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs entity.other.attribute-name.moose.perl",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -331,7 +331,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -771,7 +771,7 @@
 	},
 	{
 		"c": "has",
-		"t": "source.perl meta.role.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -782,7 +782,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -793,7 +793,7 @@
 	},
 	{
 		"c": "role_attribute",
-		"t": "source.perl meta.role.moose.perl entity.other.attribute-name.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs entity.other.attribute-name.moose.perl",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -804,7 +804,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.role.moose.perl",
+		"t": "source.perl meta.role.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1089,7 +1089,7 @@
 		}
 	},
 	{
-		"c": "TestMoosePackages",
+		"c": "TestMoosePackage",
 		"t": "source.perl meta.class.perl entity.name.type.class.perl",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -1221,6 +1221,336 @@
 		}
 	},
 	{
+		"c": " Pattern:    use Moo",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "package",
+		"t": "source.perl meta.class.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.class.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "TestMooPackage",
+		"t": "source.perl meta.class.perl entity.name.type.class.perl",
+		"r": {
+			"dark_plus": "entity.name.type: #4EC9B0",
+			"light_plus": "entity.name.type: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.type: #4EC9B0"
+		}
+	},
+	{
+		"c": " {",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: entity.name.class.moose.perl",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Moo",
+		"t": "source.perl meta.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Pattern:    use Mouse",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "package",
+		"t": "source.perl meta.class.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.class.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "TestMousePackage",
+		"t": "source.perl meta.class.perl entity.name.type.class.perl",
+		"r": {
+			"dark_plus": "entity.name.type: #4EC9B0",
+			"light_plus": "entity.name.type: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.type: #4EC9B0"
+		}
+	},
+	{
+		"c": " {",
+		"t": "source.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl punctuation.whitespace.comment.leading.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": " Assert: entity.name.class.moose.perl",
+		"t": "source.perl comment.line.number-sign.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
+		"c": "    ",
+		"t": "source.perl meta.leading-tabs meta.odd-tab",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "use",
+		"t": "source.perl keyword.control.perl",
+		"r": {
+			"dark_plus": "keyword.control: #C586C0",
+			"light_plus": "keyword.control: #AF00DB",
+			"dark_vs": "keyword.control: #569CD6",
+			"light_vs": "keyword.control: #0000FF",
+			"hc_black": "keyword.control: #C586C0"
+		}
+	},
+	{
+		"c": " ",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "Mouse",
+		"t": "source.perl meta.moose.perl entity.name.class.moose.perl",
+		"r": {
+			"dark_plus": "entity.name.class: #4EC9B0",
+			"light_plus": "entity.name.class: #267F99",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "entity.name.class: #4EC9B0"
+		}
+	},
+	{
+		"c": ";",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "}",
+		"t": "source.perl meta.moose.perl",
+		"r": {
+			"dark_plus": "default: #D4D4D4",
+			"light_plus": "default: #000000",
+			"dark_vs": "default: #D4D4D4",
+			"light_vs": "default: #000000",
+			"hc_black": "default: #FFFFFF"
+		}
+	},
+	{
+		"c": "#",
+		"t": "source.perl meta.moose.perl comment.line.number-sign.perl punctuation.definition.comment.perl",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668"
+		}
+	},
+	{
 		"c": " Pattern:    use Moose",
 		"t": "source.perl meta.moose.perl comment.line.number-sign.perl",
 		"r": {
@@ -1254,7 +1584,7 @@
 		}
 	},
 	{
-		"c": "TestMoosePackagesNo",
+		"c": "TestMoosePackageNo",
 		"t": "source.perl meta.class.perl entity.name.type.class.perl",
 		"r": {
 			"dark_plus": "entity.name.type: #4EC9B0",
@@ -1937,7 +2267,7 @@
 	},
 	{
 		"c": "extends",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl keyword.control.import.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl keyword.control.import.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -1948,7 +2278,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -2047,7 +2377,7 @@
 	},
 	{
 		"c": "with",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl keyword.control.import.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl keyword.control.import.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -2058,7 +2388,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -2069,7 +2399,7 @@
 	},
 	{
 		"c": "TestMooseRole",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl entity.name.class.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl entity.name.class.moose.perl",
 		"r": {
 			"dark_plus": "entity.name.class: #4EC9B0",
 			"light_plus": "entity.name.class: #267F99",
@@ -2234,7 +2564,7 @@
 	},
 	{
 		"c": "with",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl keyword.control.import.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl keyword.control.import.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -2245,7 +2575,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -2355,7 +2685,7 @@
 	},
 	{
 		"c": "has",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -2366,7 +2696,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2377,7 +2707,7 @@
 	},
 	{
 		"c": "attribute",
-		"t": "source.perl meta.moose.perl entity.other.attribute-name.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs entity.other.attribute-name.moose.perl",
 		"r": {
 			"dark_plus": "entity.other.attribute-name: #9CDCFE",
 			"light_plus": "entity.other.attribute-name: #FF0000",
@@ -2388,7 +2718,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2443,7 +2773,7 @@
 	},
 	{
 		"c": "auto_deref     ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -2498,7 +2828,7 @@
 	},
 	{
 		"c": "clearer        ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -2597,7 +2927,7 @@
 	},
 	{
 		"c": "coerce         ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -2652,7 +2982,7 @@
 	},
 	{
 		"c": "default        ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -2740,7 +3070,7 @@
 	},
 	{
 		"c": "documentation  ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -2839,7 +3169,7 @@
 	},
 	{
 		"c": "handles ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3169,7 +3499,7 @@
 	},
 	{
 		"c": "is             ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3268,7 +3598,7 @@
 	},
 	{
 		"c": "isa            ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3367,7 +3697,7 @@
 	},
 	{
 		"c": "lazy           ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3422,7 +3752,7 @@
 	},
 	{
 		"c": "metaclass      ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3521,7 +3851,7 @@
 	},
 	{
 		"c": "predicate      ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3620,7 +3950,7 @@
 	},
 	{
 		"c": "required       ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3675,7 +4005,7 @@
 	},
 	{
 		"c": "traits         ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3774,7 +4104,7 @@
 	},
 	{
 		"c": "trigger        ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3884,7 +4214,7 @@
 	},
 	{
 		"c": "weak_ref       ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -3983,7 +4313,7 @@
 	},
 	{
 		"c": "has",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -3994,7 +4324,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -4093,7 +4423,7 @@
 	},
 	{
 		"c": "is         ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -4192,7 +4522,7 @@
 	},
 	{
 		"c": "builder    ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -4291,7 +4621,7 @@
 	},
 	{
 		"c": "does       ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -4390,7 +4720,7 @@
 	},
 	{
 		"c": "lazy_build ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -4445,7 +4775,7 @@
 	},
 	{
 		"c": "role_attribute ",
-		"t": "source.perl meta.moose.perl constant.language.has.key.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs constant.language.has.key.moose.perl",
 		"r": {
 			"dark_plus": "constant.language: #569CD6",
 			"light_plus": "constant.language: #0000FF",
@@ -4819,7 +5149,7 @@
 	},
 	{
 		"c": "extends",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl keyword.control.import.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl keyword.control.import.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -4830,7 +5160,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -5017,7 +5347,7 @@
 	},
 	{
 		"c": "before",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -5028,7 +5358,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -5039,7 +5369,7 @@
 	},
 	{
 		"c": "method",
-		"t": "source.perl meta.moose.perl entity.name.function.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs entity.name.function.perl",
 		"r": {
 			"dark_plus": "entity.name.function: #DCDCAA",
 			"light_plus": "entity.name.function: #795E26",
@@ -5050,7 +5380,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -5182,7 +5512,7 @@
 	},
 	{
 		"c": "after",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -5193,7 +5523,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -5369,7 +5699,7 @@
 	},
 	{
 		"c": "around",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -5380,7 +5710,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -5831,7 +6161,7 @@
 	},
 	{
 		"c": "augment",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -5842,7 +6172,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -5996,7 +6326,7 @@
 	},
 	{
 		"c": "override",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -6007,7 +6337,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -6282,7 +6612,7 @@
 	},
 	{
 		"c": "extends",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl keyword.control.import.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl keyword.control.import.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -6293,7 +6623,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl keyword.control.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.control.moose.perl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",
 			"light_plus": "keyword.control: #AF00DB",
@@ -6359,7 +6689,7 @@
 	},
 	{
 		"c": "augment",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -6370,7 +6700,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -6381,7 +6711,7 @@
 	},
 	{
 		"c": "base_method1",
-		"t": "source.perl meta.moose.perl entity.name.function.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs entity.name.function.perl",
 		"r": {
 			"dark_plus": "entity.name.function: #DCDCAA",
 			"light_plus": "entity.name.function: #795E26",
@@ -6392,7 +6722,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -6788,7 +7118,7 @@
 	},
 	{
 		"c": "confess",
-		"t": "source.perl meta.moose.perl support.function.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs support.function.moose.perl",
 		"r": {
 			"dark_plus": "support.function: #DCDCAA",
 			"light_plus": "support.function: #795E26",
@@ -6799,7 +7129,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -7338,7 +7668,7 @@
 	},
 	{
 		"c": "override",
-		"t": "source.perl meta.moose.perl keyword.other.attribute.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs keyword.other.attribute.moose.perl",
 		"r": {
 			"dark_plus": "keyword: #569CD6",
 			"light_plus": "keyword: #0000FF",
@@ -7349,7 +7679,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -7360,7 +7690,7 @@
 	},
 	{
 		"c": "base_method2",
-		"t": "source.perl meta.moose.perl entity.name.function.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs entity.name.function.perl",
 		"r": {
 			"dark_plus": "entity.name.function: #DCDCAA",
 			"light_plus": "entity.name.function: #795E26",
@@ -7371,7 +7701,7 @@
 	},
 	{
 		"c": " ",
-		"t": "source.perl meta.moose.perl",
+		"t": "source.perl meta.moose.perl meta.leading-tabs",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",


### PR DESCRIPTION
When multiple Moose Packages are used in the same perl file. The syntax is not highlighted well. This PR fixes that injecting the grammar into meta scope